### PR TITLE
Adding sanitytest.js to track implemented function count

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "generate": "npm run generate:all && npm run generate:format",
     "generate:all": "node src/main.js",
     "generate:format": "npx clang-format -i -style=Google generated/*",
-    "check": "npm run check:libvirt_min_ver & npm run check:libvirt_api_xml",
+    "check": "npm run check:libvirt_min_ver & npm run check:libvirt_api_xml & npm run check:sanity",
+    "check:sanity": "node tools/sanitytest.js",
     "check:libvirt_api_xml": "node tools/api_xml_files.js",
     "check:libvirt_min_ver": "node tools/check_min_libvirt_ver.js"
   },

--- a/tools/sanitytest.js
+++ b/tools/sanitytest.js
@@ -1,0 +1,59 @@
+const { whitelist } = require('../src/whitelist');
+const { libvirt_parser } = require('../src/parser');
+
+/** Copied from libvirt-python's sanitytest.py **/
+function ignore(name) {
+    if(name.startsWith('virTypedParams') ||
+       name.startsWith('virNetworkDHCPLeaseFree') ||
+       name.startsWith('virDomainStatsRecordListFree') ||
+       name.startsWith('virDomainFSInfoFree') ||
+       name.startsWith('virDomainIOThreadInfoFree') ||
+       name.startsWith('virDomainInterfaceFree'))
+    {
+        return true;
+    }
+    if(["virConnectAuthCallbackPtr", "virConnectCloseFunc",
+        "virStreamSinkFunc", "virStreamSourceFunc", "virStreamEventCallback",
+        "virEventHandleCallback", "virEventTimeoutCallback", "virFreeCallback",
+        "virStreamSinkHoleFunc", "virStreamSourceHoleFunc", "virStreamSourceSkipFunc"]
+        .includes(name))
+    {
+        return true;
+    }
+    if(name.endsWith('Callback')) {
+        if(name.startsWith('virConnectDomainEvent') ||
+           name.startsWith('virConnectNetworkEvent') ||
+           name.startsWith('virConnectStoragePoolEvent') ||
+           name.startsWith('virConnectNodeDeviceEvent') ||
+           name.startsWith('virConnectSecretEvent'))
+        {
+            return true;
+        }
+    }
+    if(name.startsWith('virEvent') && name.endsWith('Func')){
+        return true;
+    }
+
+    return false;
+}
+
+((parser) => {
+    let allowed = [],
+        skipped = [];
+
+    Object.values(parser.functions).forEach(func => {
+        if(ignore(func.name))
+            return;
+
+        if(whitelist.has(func.name)) {
+            allowed.push(func);
+        } else {
+            skipped.push(func);
+        }
+    });
+
+    // skipped.forEach(func => console.log(func.name));
+
+    console.log(`${allowed.length}/${allowed.length + skipped.length} implemented`);
+    console.log(`${allowed.length * 100 / (allowed.length + skipped.length)}%`);
+})(libvirt_parser);


### PR DESCRIPTION
I've added a dumb sanitytest that compares the API to our whitelist.

In the future might want to:
1- report interface and C binding separately
2- use the actual libvirt-node API to check if implemented (or emitters).