### PR TITLE
set package manifest's "main" attribute to correct path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "libvirt-node",
   "version": "0.1.0",
   "description": "The libvirt virtualization API node.js binding",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "install": "npm run check & npm run generate",
     "postinstall": "node-gyp rebuild",


### PR DESCRIPTION
Currently, this package doesn't work when you `require('libvirt-node')` because the path in the package manifest's "main" attribute is incorrect. This fixes that issue.