### PR TITLE
Add Dockerfile to check if build is passing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,5 @@ RUN echo "deb http://security.debian.org/ jessie/updates main contrib" >> /etc/a
   make -j3 && \
   make install
 COPY . .
-# ENTRYPOINT [ "/bin/bash" ]
 RUN make && make check
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:8
+ENV LD_LIBRARY_PATH=/usr/src/libvirt-vroot/lib
+ENV PKG_CONFIG_PATH=/usr/src/libvirt-vroot/lib/pkgconfig
+ENV LIBVIRT=3.6.0
+ENV EXT=xz
+WORKDIR /usr/src
+RUN echo "deb http://security.debian.org/ jessie/updates main contrib" >> /etc/apt/sources.list && \
+  echo "deb-src http://security.debian.org/ jessie/updates main contrib" >> /etc/apt/sources.list && \
+  apt-get update -y && apt-get upgrade -y && \
+  apt-get install -y build-essential curl && \
+  curl -O -s https://libvirt.org/sources/libvirt-${LIBVIRT}.tar.${EXT} && \
+  tar -xf libvirt-${LIBVIRT}.tar.${EXT} && \
+  cd libvirt-${LIBVIRT} && \
+  ./configure --prefix=`pwd`/../libvirt-vroot \
+    --without-libvirtd \
+    --without-esx \
+    --without-vbox \
+    --without-libxl \
+    --without-xen \
+    --without-qemu \
+    --without-lxc \
+    --without-hyperv \
+    --without-macvtap \
+    --disable-werror && \
+  make -j3 && \
+  make install
+COPY . .
+# ENTRYPOINT [ "/bin/bash" ]
+RUN make && make check
+

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ clean:
 
 check:
 	$(NPM) run test
+
+docker:
+	docker build .

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ The [whitelist][whitelist] has the supported (and not yet supported) functions.
 
 For development documentation please refer to [DEVELOPMENT.md][development]
 
+## Build in docker container
+If you already installed docker locally, you can check build by
+
+    make docker
+
 ## License
 
 libvirt-node is released under LGPL-2.1

--- a/src/generators/impls/impl_list_all.js
+++ b/src/generators/impls/impl_list_all.js
@@ -59,13 +59,13 @@ impl_emitter.register('vir[\\w]+ListAll[\\w]+', (func) => {
             }
         `;
 
-        out += args_generator.getGen(napiValueType)(func.args[2], 1);
+        out += args_generator.getGen(napiValueType)(func.args[2], 2);
     }
 
     // perform C call
     out += `
-        ${func.args[1].type.replace('**', '*')} list = NULL;
-        ${func.ret[0].type} c_retval = ${func.name}(arg0, &list, arg1);
+        ${func.args[1].type.replace('**', '*')} arg1 = NULL;
+        ${func.ret[0].type} c_retval = ${func.name}(arg0, &arg1, arg2);
     `;
 
     // return if null ptr
@@ -83,7 +83,7 @@ impl_emitter.register('vir[\\w]+ListAll[\\w]+', (func) => {
 
         int i = 0;
         for(; i < c_retval; ++i) {
-            status = napi_create_external(env, list[i], NULL, NULL, &temp_val);
+            status = napi_create_external(env, arg1[i], NULL, NULL, &temp_val);
             assert(status == napi_ok);  
 
             status = napi_set_element(env, n_retval, i, temp_val);

--- a/src/generators/impls/impl_list_all.js
+++ b/src/generators/impls/impl_list_all.js
@@ -59,13 +59,13 @@ impl_emitter.register('vir[\\w]+ListAll[\\w]+', (func) => {
             }
         `;
 
-        out += args_generator.getGen(napiValueType)(func.args[2], 2);
+        out += args_generator.getGen(napiValueType)(func.args[2], 1);
     }
 
     // perform C call
     out += `
-        ${func.args[1].type.replace('**', '*')} arg1 = NULL;
-        ${func.ret[0].type} c_retval = ${func.name}(arg0, &arg1, arg2);
+        ${func.args[1].type.replace('**', '*')} list = NULL;
+        ${func.ret[0].type} c_retval = ${func.name}(arg0, &list, arg1);
     `;
 
     // return if null ptr
@@ -83,7 +83,7 @@ impl_emitter.register('vir[\\w]+ListAll[\\w]+', (func) => {
 
         int i = 0;
         for(; i < c_retval; ++i) {
-            status = napi_create_external(env, arg1[i], NULL, NULL, &temp_val);
+            status = napi_create_external(env, list[i], NULL, NULL, &temp_val);
             assert(status == napi_ok);  
 
             status = napi_set_element(env, n_retval, i, temp_val);


### PR DESCRIPTION
To build in docker container

```
make docker
```

output
```
masahiromatsui:~/libvirt-node$ make docker
docker build .
Sending build context to Docker daemon  40.32MB
Step 1/9 : FROM node:8
 ---> 8eeadf3757f4
Step 2/9 : ENV LD_LIBRARY_PATH=/usr/src/libvirt-vroot/lib
 ---> Using cache
 ---> 1ea82739e5e6
Step 3/9 : ENV PKG_CONFIG_PATH=/usr/src/libvirt-vroot/lib/pkgconfig
 ---> Using cache
 ---> 8540e03f142b
Step 4/9 : ENV LIBVIRT=3.6.0
 ---> Using cache
 ---> be07d4950b48
Step 5/9 : ENV EXT=xz
 ---> Using cache
 ---> 5f2e56d2f666
Step 6/9 : WORKDIR /usr/src
 ---> Using cache
 ---> 55e80eb817ae
Step 7/9 : RUN echo "deb http://security.debian.org/ jessie/updates main contrib" >> /etc/apt/sources.list &&   echo "deb-src http://security.debian.org/ jessie/updates main contrib" >> /etc/apt/sources.list &&   apt-get update -y && apt-get upgrade -y &&   apt-get install -y build-essential curl &&   curl -O -s https://libvirt.org/sources/libvirt-${LIBVIRT}.tar.${EXT} &&   tar -xf libvirt-${LIBVIRT}.tar.${EXT} &&   cd libvirt-${LIBVIRT} &&   ./configure --prefix=`pwd`/../libvirt-vroot     --without-libvirtd     --without-esx     --without-vbox     --without-libxl     --without-xen     --without-qemu     --without-lxc     --without-hyperv     --without-macvtap     --disable-werror &&   make -j3 &&   make install
 ---> Using cache
 ---> fcdad7542c36
Step 8/9 : COPY . .
 ---> 323913dac970
Step 9/9 : RUN make && make check
 ---> Running in f3bd0549a8d4
npm i
npm WARN lifecycle libvirt-node@0.1.0~install: cannot run in wd libvirt-node@0.1.0 npm run check & npm run generate (wd=/usr/src)
npm WARN lifecycle libvirt-node@0.1.0~postinstall: cannot run in wd libvirt-node@0.1.0 node-gyp rebuild (wd=/usr/src)
removed 106 packages, updated 8 packages and audited 57 packages in 2.598s
found 0 vulnerabilities

npm run test

> libvirt-node@0.1.0 test /usr/src
> npx mocha



  libvirt-connect
    ✓ should get the uri
    ✓ should check if connection is alive
    ✓ should get capabilities
 11 <

  libvirt-domain
    ✓ should list all domains
libvirt: Test Driver error : Domain not found
    ✓ should create and destroy domain from xml
    domain lookups
      ✓ should lookup by name
      ✓ should lookup by ID
      ✓ should lookup with too many arguments
libvirt: Test Driver error : Domain not found
      ✓ should fail to lookup with incorrect name
      ✓ should fail to lookup with wrong argument type
    domain setters/getters
      ✓ should get the domain ID
      ✓ should get the OS type
      ✓ should set/get vCPUs
      ✓ should set/get MaxMemory
    domain actions
      ✓ should reboot the domain
      ✓ should suspend and resume the domain

  libvirt-storage-pool
    ✓ should lookup by name
    ✓ should list all storage pools
libvirt: Test Driver error : Storage pool not found: no storage pool with matching name 'storage_pool_test'
    ✓ should create and destroy storagePool from xml
    storagePool actions
      ✓ should get number of volumes
      ✓ should refresh the list of volumes

  libvirt
    ✓ should openReadOnly
    open
      ✓ should connect with default uri
      ✓ should connect with too many arguments
libvirt:  error : no connection driver available for malformed
      ✓ should fail to connect with malformed uri
      ✓ should fail to connect with wrong argument type
      ✓ should close and return 0


  27 passing (75ms)
```

This PR resolves #41.